### PR TITLE
Vector2: clone() and normalize() added

### DIFF
--- a/src/math/__test__/vector2.test.ts
+++ b/src/math/__test__/vector2.test.ts
@@ -23,6 +23,12 @@ describe('Vector2', () => {
     expect(new Vector2(2, 3).scale(3)).toEqual(new Vector2(6, 9));
   });
 
+  test('normalize', () => {
+    expect(new Vector2(0, 10).normalize()).toStrictEqual(new Vector2(0, 1));
+    expect(new Vector2(2, 3).normalize().getLength().toFixed(2)).toEqual('1.00');
+    expect(new Vector2(10, 11).normalize().getLength().toFixed(2)).toEqual('1.00');
+  });
+
   test('equalsTo', () => {
     expect(new Vector2(1, 2).equalsTo({ x: 1, y: 2 })).toBe(true);
     expect(new Vector2(1, 2).equalsTo(new Vector2(1, 2))).toBe(true);
@@ -47,5 +53,17 @@ describe('Vector2', () => {
     const result = new Vector2(20, 30).toJSON();
 
     expect(result).toStrictEqual({ x: 20, y: 30 });
+  });
+
+  test('clone', () => {
+    const a = new Vector2(20, 30);
+    const b = a.clone();
+
+    expect(a instanceof Vector2).toBe(true);
+    expect(b instanceof Vector2).toBe(true);
+    expect(a.x === b.x && a.y === b.y).toBe(true);
+    expect(a !== b).toBe(true);
+    expect(a.equalsTo(b)).toBe(true);
+    expect(b.equalsTo(a)).toBe(true);
   });
 });

--- a/src/math/vector2.ts
+++ b/src/math/vector2.ts
@@ -43,6 +43,14 @@ export class Vector2 implements Point2d {
   }
 
   /**
+   * Returns new instance of Vector2 with same x and y.
+   * @returns New instance.
+   */
+  clone() {
+    return new Vector2(this.x, this.y);
+  }
+
+  /**
    * Sets the X coordinate.
    */
   setX(x: number): this {
@@ -89,6 +97,17 @@ export class Vector2 implements Point2d {
   scale(scalar: number): this {
     this.x *= scalar;
     this.y *= scalar;
+
+    return this;
+  }
+
+  /**
+   * Makes length equals to 1.
+   */
+  normalize() {
+    const value = 1 / this.getLength();
+    this.x *= value;
+    this.y *= value;
 
     return this;
   }

--- a/src/math/vector2.ts
+++ b/src/math/vector2.ts
@@ -46,7 +46,7 @@ export class Vector2 implements Point2d {
    * Returns new instance of Vector2 with same x and y.
    * @returns New instance.
    */
-  clone() {
+  clone(): Vector2 {
     return new Vector2(this.x, this.y);
   }
 
@@ -104,7 +104,7 @@ export class Vector2 implements Point2d {
   /**
    * Makes length equals to 1.
    */
-  normalize() {
+  normalize(): this {
     const value = 1 / this.getLength();
     this.x *= value;
     this.y *= value;


### PR DESCRIPTION
- `math`: Vector2 now has `clone()` and `normalize()` methods