### PR TITLE
Rspack fixes and debounce

### DIFF
--- a/src/misc/__test__/debounce.test.ts
+++ b/src/misc/__test__/debounce.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, mock } from 'node:test';
+import { debounce } from '../debounce.ts';
+import { expect } from '@std/expect';
+
+const wait = (ms: number) => new Promise(done => setTimeout(done, ms));
+
+describe('debounce', () => {
+  test('should work properly', async () => {
+    const spy = mock.fn();
+    const debounced = debounce(spy, 200);
+
+    // check initial call delay
+    debounced();
+    expect(spy.mock.callCount()).toEqual(0);
+
+    await wait(200);
+    expect(spy.mock.callCount()).toEqual(1);
+
+    spy.mock.resetCalls();
+
+    // check debounce when multiple calls with delay < timeout
+    debounced();
+    await wait(100);
+    expect(spy.mock.callCount()).toEqual(0);
+
+    debounced();
+    await wait(100);
+    expect(spy.mock.callCount()).toEqual(0);
+
+    debounced();
+    await wait(100);
+    expect(spy.mock.callCount()).toEqual(0);
+
+    await wait(100);
+    expect(spy.mock.callCount()).toEqual(1);
+  });
+});

--- a/src/misc/debounce.ts
+++ b/src/misc/debounce.ts
@@ -1,0 +1,22 @@
+/**
+ * Simplest implementation of "debounce" function.
+ * Returns function wrapper that delays original function call
+ * until timeout since last call will be reached.
+ * Analogue of debounce from lodash/underscore.
+ *
+ * @param func Function.
+ * @param timeout Timeout in milliseconds.
+ * @returns Debounced function.
+ */
+export function debounce<T extends (...args: any) => any>(
+  func: T,
+  timeout: number,
+): (...args: Parameters<T>) => void {
+  let timerId: ReturnType<typeof setTimeout>;
+
+  return (...args) => {
+    clearTimeout(timerId);
+
+    timerId = setTimeout(() => func(...args), timeout);
+  };
+}

--- a/src/misc/mod.ts
+++ b/src/misc/mod.ts
@@ -1,3 +1,4 @@
+export * from './debounce.ts';
 export * from './for-each-pair.ts';
 export * from './memo-return-array.ts';
 export * from './pairs.ts';

--- a/src/rspack/mod.ts
+++ b/src/rspack/mod.ts
@@ -2,6 +2,8 @@ export * from './plugin-css.ts';
 export * from './plugin-html.ts';
 export * from './plugin-import-meta-env.ts';
 export * from './plugin-public-folder.ts';
+export * from './plugin-raw-import.ts';
 export * from './plugin-react-svg.ts';
 export * from './plugin-static-assets.ts';
 export * from './plugin-typescript.ts';
+export type * from './types.ts';

--- a/src/rspack/plugin-raw-import.tsx
+++ b/src/rspack/plugin-raw-import.tsx
@@ -1,0 +1,51 @@
+import type { RspackPluginFunction, RuleSetRule } from '@rspack/core';
+import type { RuleInsertOptions } from './types.ts';
+
+export interface PluginRawImportOptions extends RuleInsertOptions {
+  /** Rule extension/override. */
+  ruleOverride?: RuleSetRule;
+}
+
+/**
+ * Rspack plugin that that allows importing files as a string.
+ * It is analogue of `raw-loader` that adds rule with `resourceQuery` and `type: 'asset/source'`.
+ * By default it uses `?raw` query so every file can be imported as string with this query.
+ *
+ * @example
+ * ```js
+ * // rspack.config.js
+ * import { pluginRawImport } from '@krutoo/utils/rspack';
+ *
+ * export default {
+ *   plugins: [
+ *     pluginRawImport(),
+ *   ],
+ *   // ...other config
+ * };
+ * ```
+ *
+ * @param options Options.
+ * @returns Plugin function.
+ */
+export function pluginRawImport({
+  ruleInsert: insertRule = 'to-end',
+  ruleOverride,
+}: PluginRawImportOptions = {}): RspackPluginFunction {
+  return compiler => {
+    compiler.hooks.afterEnvironment.tap('krutoo:pluginRawImport', () => {
+      const rule: RuleSetRule = {
+        resourceQuery: /raw/,
+        type: 'asset/source',
+        ...ruleOverride,
+      };
+
+      if (insertRule === 'to-start') {
+        compiler.options.module.rules.unshift(rule);
+      }
+
+      if (insertRule === 'to-end') {
+        compiler.options.module.rules.push(rule);
+      }
+    });
+  };
+}

--- a/src/rspack/types.ts
+++ b/src/rspack/types.ts
@@ -1,0 +1,4 @@
+export interface RuleInsertOptions {
+  /** How to insert rule to list of rules in configuration. */
+  ruleInsert?: 'to-start' | 'to-end';
+}


### PR DESCRIPTION
- rspack: pluginRawImport added (minor)
- debounce added (minor)
- rspack: pluginTypeScript now has ability to override result rule (minor)
- rspack: pluginTypeScript now has ability to disable rule (minor)
- rspack: pluginTypeScript now has ability to configure how to insert rule (minor)
- rspack: pluginTypeScript result rule now don't have `type: 'javascript/auto'` because of bad compatibility with raw import plugin (patch)
