### PR TITLE
February fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Collection of useful utils for JavaScript/TypeScript projects. Some utilities ar
 ## Installation
 
 ```bash
-# Node (from NPM)
+# In Node.js
 npm add @krutoo/utils
 
-# Deno (from JSR)
-deno add jsr:@krutoo/utils
+# In Deno
+deno add npm:@krutoo/utils
 
-# Bun (from NPM)
+# In Bun
 bun add @krutoo/utils
 ```
 

--- a/src/dom/get-positioned-parent-offset.ts
+++ b/src/dom/get-positioned-parent-offset.ts
@@ -23,7 +23,23 @@ export function getPositionedParentOffset(element: HTMLElement): Point2d {
     return { x: 0, y: 0 };
   }
 
-  const offsetParent = element.offsetParent;
+  let offsetParent = element.offsetParent;
+
+  // according to MDN:
+  // "If there is no positioned ancestor element, the body is returned."
+  //
+  // because of this, we need to check real offset of body
+  // and if is it non zero we need to change offsetParent to document.documentElement
+  //
+  // @todo maybe it is reasonable to restore function like `getOffsetParent`
+  if (offsetParent === document.body) {
+    const bodyRect = document.body.getBoundingClientRect();
+
+    if (bodyRect.left !== 0 || bodyRect.top !== 0) {
+      offsetParent = document.documentElement;
+    }
+  }
+
   const scrollParent = findScrollParent(element) ?? document.documentElement;
 
   const offset: Point2d = {
@@ -43,7 +59,7 @@ export function getPositionedParentOffset(element: HTMLElement): Point2d {
     offset.y += cssValueToNumber(parentStyle.borderTopWidth);
   }
 
-  // ВАЖНО: check offsetParent's scrollTop/scrollLeft
+  // IMPORTANT: check offsetParent's scrollTop/scrollLeft
   if (offsetParent && offsetParent === scrollParent) {
     offset.x += scrollParent.scrollLeft;
     offset.y += scrollParent.scrollTop;

--- a/src/react/use-identity-ref.ts
+++ b/src/react/use-identity-ref.ts
@@ -2,7 +2,7 @@ import { type MutableRefObject, useMemo, useRef } from 'react';
 
 /**
  * Returns ref that automatically actualizes current value.
- * Useful when you need to store actual value.
+ * Useful when you need to store actual value and pass it to effect without rerunning.
  *
  * @example
  * ```tsx
@@ -12,9 +12,10 @@ import { type MutableRefObject, useMemo, useRef } from 'react';
  *   const countRef = useIdentityRef(count);
  *
  *   // ref will always contain actual value
- *   console.assert(count, countRef.current)
+ *   // so you can read this ref inside effects without rerunning
+ *   console.assert(count === countRef.current);
  *
- *   return <div>Count: {count}</div>
+ *   return <div>Count: {count}</div>;
  * }
  * ```
  *


### PR DESCRIPTION
- dom: getPositionedParentOffset now correctly defines offsetParent (patch)
- react: useIdentityRef JSDoc fixes (patch)
- rspack: pluginTypeScript now correctly affects `resolve.extensions` so you can skip it option in your config (patch)