### PR TITLE
React 19 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@std/expect": "npm:@jsr/std__expect@^1.0.9",
         "@testing-library/react": "^16.1.0",
         "@types/node": "^22.10.2",
-        "@types/react": "^18.3.16",
+        "@types/react": "^19.0.10",
         "eslint": "^9.17.0",
         "eslint-plugin-jsdoc": "^50.6.1",
         "eslint-plugin-react": "^7.37.2",
@@ -22,6 +22,7 @@
         "global-jsdom": "^25.0.0",
         "globals": "^15.13.0",
         "prettier": "^3.4.2",
+        "react": "^19.0.0",
         "tsimp": "^2.0.12",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.18.1"
@@ -33,7 +34,7 @@
         "@rspack/core": "^1.1.8",
         "@svgr/webpack": "^8.1.0",
         "css-loader": "^7.1.2",
-        "react": "^18 || ^19"
+        "react": "^17 || ^18 || ^19"
       },
       "peerDependenciesMeta": {
         "@rspack/core": {
@@ -2943,21 +2944,13 @@
         "undici-types": "~6.20.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.16",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.16.tgz",
-      "integrity": "sha512-oh8AMIC4Y2ciKufU8hnKgs+ufgbA/dhPTACaZPM86AbwX9QwnFtSoPWEeRUj8fge+v6kFt78BXcDhAU1SrrAsw==",
+      "version": "19.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
+      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -6826,9 +6819,8 @@
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@std/expect": "npm:@jsr/std__expect@^1.0.9",
     "@testing-library/react": "^16.1.0",
     "@types/node": "^22.10.2",
-    "@types/react": "^18.3.16",
+    "@types/react": "^19.0.10",
     "eslint": "^9.17.0",
     "eslint-plugin-jsdoc": "^50.6.1",
     "eslint-plugin-react": "^7.37.2",
@@ -35,6 +35,7 @@
     "global-jsdom": "^25.0.0",
     "globals": "^15.13.0",
     "prettier": "^3.4.2",
+    "react": "^19.0.0",
     "tsimp": "^2.0.12",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.18.1"
@@ -43,7 +44,7 @@
     "@rspack/core": "^1.1.8",
     "@svgr/webpack": "^8.1.0",
     "css-loader": "^7.1.2",
-    "react": "^18 || ^19"
+    "react": "^17 || ^18 || ^19"
   },
   "peerDependenciesMeta": {
     "@rspack/core": {

--- a/src/react/query/query-manager.tsx
+++ b/src/react/query/query-manager.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, ReactNode, Context } from 'react';
+import { createContext, useContext, type ReactNode, type Context, type JSX } from 'react';
 import type { QueryManager } from './types.ts';
 
 export const QueryMangerContext: Context<QueryManager | null> = createContext<QueryManager | null>(

--- a/src/react/use-bounding-client-rect.ts
+++ b/src/react/use-bounding-client-rect.ts
@@ -1,4 +1,4 @@
-import { type DependencyList, type RefObject, useState } from 'react';
+import { type DependencyList, MutableRefObject, type RefObject, useState } from 'react';
 import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect.ts';
 
 export type DOMRectShape = Pick<
@@ -61,7 +61,13 @@ function isRectsEqual(a: DOMRectShape, b: DOMRectShape) {
  * @returns Rect state.
  */
 export function useBoundingClientRect<T extends Element>(
-  ref: RefObject<T>,
+  ref:
+    | RefObject<T>
+    | RefObject<T | null>
+    | RefObject<T | undefined>
+    | MutableRefObject<T>
+    | MutableRefObject<T | null>
+    | MutableRefObject<T | undefined>,
   extraDeps: DependencyList = [],
 ): DOMRectState {
   const [state, setState] = useState<DOMRectState>(DEFAULT_STATE);

--- a/src/react/use-drag-and-drop.ts
+++ b/src/react/use-drag-and-drop.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useState, DependencyList } from 'react';
+import { type RefObject, useEffect, useState, DependencyList, MutableRefObject } from 'react';
 import { type Point2d, Vector2 } from '../math/mod.ts';
 import { useStableCallback } from './use-stable-callback.ts';
 import { getPositionedParentOffset } from '../dom/mod.ts';
@@ -27,7 +27,13 @@ export interface UseDragAndDropReturn {
  * @returns State.
  */
 export function useDragAndDrop<T extends HTMLElement>(
-  ref: RefObject<T>,
+  ref:
+    | RefObject<T>
+    | RefObject<T | null>
+    | RefObject<T | undefined>
+    | MutableRefObject<T>
+    | MutableRefObject<T | null>
+    | MutableRefObject<T | undefined>,
   { disabled, onGrab, onMove, onDrop, extraDeps = [] }: UseDragAndDropOptions = {},
 ): UseDragAndDropReturn {
   const [captured, setCaptured] = useState<boolean>(false);


### PR DESCRIPTION
- react: react in peer now 17 || 18 || 19
- react: types that are used in hooks now updated for 18/19 support