### PR TITLE
New React Web API hooks

### DIFF
--- a/src/react/context/intersection-observer-context.ts
+++ b/src/react/context/intersection-observer-context.ts
@@ -1,0 +1,16 @@
+import { type Context, createContext } from 'react';
+
+export interface IntersectionObserverContextValue {
+  getObserver: (
+    callback: IntersectionObserverCallback,
+    options?: IntersectionObserverInit,
+  ) => IntersectionObserver;
+}
+
+export const IntersectionObserverContext: Context<IntersectionObserverContextValue> = createContext(
+  {
+    getObserver(callback, options) {
+      return new IntersectionObserver(callback, options);
+    },
+  },
+);

--- a/src/react/context/match-media-context.ts
+++ b/src/react/context/match-media-context.ts
@@ -1,0 +1,13 @@
+import { Context, createContext } from 'react';
+
+export interface MatchMediaContextValue {
+  matchMedia: (query: string) => MediaQueryList;
+}
+
+export const MatchMediaContext: Context<MatchMediaContextValue> = createContext({
+  // IMPORTANT: we should use match media global inside function instead pass it to defaultValue of context
+  // it is because context may be used in environment that has not `matchMedia` global
+  matchMedia(query) {
+    return matchMedia(query);
+  },
+});

--- a/src/react/context/resize-observer-context.ts
+++ b/src/react/context/resize-observer-context.ts
@@ -1,0 +1,11 @@
+import { type Context, createContext } from 'react';
+
+export interface ResizeObserverContextValue {
+  getObserver: (callback: ResizeObserverCallback) => ResizeObserver;
+}
+
+export const ResizeObserverContext: Context<ResizeObserverContextValue> = createContext({
+  getObserver(callback) {
+    return new ResizeObserver(callback);
+  },
+});

--- a/src/react/mod.ts
+++ b/src/react/mod.ts
@@ -5,12 +5,19 @@ export * from './use-isomorphic-layout-effect.ts';
 export * from './use-previous-state.ts';
 export * from './use-stable-callback.ts';
 
+// context
+export * from './context/intersection-observer-context.ts';
+export * from './context/match-media-context.ts';
+export * from './context/resize-observer-context.ts';
+
 // web api
 export * from './use-bounding-client-rect.ts';
 export * from './use-drag-and-drop.ts';
 export * from './use-exact-click.ts';
+export * from './use-intersection.ts';
 export * from './use-match-media.ts';
 export * from './use-outside-click.ts';
+export * from './use-resize.ts';
 export * from './use-storage-item.ts';
 export * from './use-visual-viewport.ts';
 export * from './use-window-size.ts';

--- a/src/react/use-intersection.ts
+++ b/src/react/use-intersection.ts
@@ -1,0 +1,65 @@
+import { type RefObject, type MutableRefObject, useContext } from 'react';
+import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect.ts';
+import { useIdentityRef } from './use-identity-ref.ts';
+import { IntersectionObserverContext } from './context/intersection-observer-context.ts';
+
+/**
+ * Rect hook of using IntersectionObserver on element.
+ *
+ * @example
+ * ```tsx
+ * import { useIntersection } from '@krutoo/utils/react';
+ *
+ * export function App () {
+ *   const ref = useRef<HTMLDivElement>(null);
+ *
+ *   useIntersection(ref, (entry) => {
+ *     console.log(entry.isIntersecting ? 'On screen' : 'Off screen');
+ *   });
+ *
+ *   return <div ref={ref}>Hello!</div>;
+ * }
+ * ```
+ *
+ * @param ref Ref with element.
+ * @param callback Observer callback.
+ * @param options Observe options.
+ */
+export function useIntersection<T extends Element>(
+  ref:
+    | RefObject<T>
+    | RefObject<T | null>
+    | RefObject<T | undefined>
+    | MutableRefObject<T>
+    | MutableRefObject<T | null>
+    | MutableRefObject<T | undefined>,
+  callback: (entry: IntersectionObserverEntry) => void,
+  options?: IntersectionObserverInit,
+): void {
+  const { getObserver } = useContext(IntersectionObserverContext);
+
+  const callbackRef = useIdentityRef(callback);
+  const optionsRef = useIdentityRef(options);
+
+  useIsomorphicLayoutEffect(() => {
+    const element = ref.current;
+
+    if (!element) {
+      return;
+    }
+
+    const observer = getObserver(entries => {
+      for (const entry of entries) {
+        if (entry.target === element) {
+          callbackRef.current(entry);
+        }
+      }
+    }, optionsRef.current);
+
+    observer.observe(element);
+
+    return () => {
+      observer.unobserve(element);
+    };
+  }, [ref, callbackRef, optionsRef, getObserver]);
+}

--- a/src/react/use-match-media.ts
+++ b/src/react/use-match-media.ts
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect.ts';
+import { MatchMediaContext } from './context/match-media-context.ts';
 
 /**
  * Hook of state of match media query.
@@ -23,6 +24,8 @@ import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect.ts';
  * @returns Boolean.
  */
 export function useMatchMedia(query: string): boolean {
+  const { matchMedia } = useContext(MatchMediaContext);
+
   const [state, setState] = useState(false);
 
   useIsomorphicLayoutEffect(() => {
@@ -39,7 +42,7 @@ export function useMatchMedia(query: string): boolean {
     return () => {
       mql.removeEventListener('change', syncState);
     };
-  }, [query]);
+  }, [query, matchMedia]);
 
   return state;
 }

--- a/src/react/use-resize.ts
+++ b/src/react/use-resize.ts
@@ -1,0 +1,62 @@
+import { type RefObject, type MutableRefObject, useContext } from 'react';
+import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect.ts';
+import { useIdentityRef } from './use-identity-ref.ts';
+import { ResizeObserverContext } from './context/resize-observer-context.ts';
+
+/**
+ * React hook for observe element resizing.
+ *
+ * @example
+ * ```tsx
+ * import { useResize } from '@krutoo/utils/react';
+ *
+ * export function App () {
+ *   const ref = useRef<HTMLDivElement>(null);
+ *
+ *   useResize(ref, (entry) => {
+ *     console.log(`Element was resized`);
+ *   });
+ *
+ *   return <div ref={ref}>Hello!</div>;
+ * }
+ * ```
+ *
+ * @param ref Element ref.
+ * @param callback Resize observer callback.
+ */
+export function useResize<T extends Element>(
+  ref:
+    | RefObject<T>
+    | RefObject<T | null>
+    | RefObject<T | undefined>
+    | MutableRefObject<T>
+    | MutableRefObject<T | null>
+    | MutableRefObject<T | undefined>,
+  callback: (entry: ResizeObserverEntry) => void,
+): void {
+  const { getObserver } = useContext(ResizeObserverContext);
+
+  const callbackRef = useIdentityRef(callback);
+
+  useIsomorphicLayoutEffect(() => {
+    const element = ref.current;
+
+    if (!element) {
+      return;
+    }
+
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        if (entry.target === element) {
+          callbackRef.current(entry);
+        }
+      }
+    });
+
+    observer.observe(element);
+
+    return () => {
+      observer.unobserve(element);
+    };
+  }, [ref, callbackRef, getObserver]);
+}


### PR DESCRIPTION
- `react`: `IntersectionObserverContext` added (minor)
- `react`: `MatchMediaContext` added (minor)
- `react`: `ResizeObserverContext` added (minor)
- `react`: `useIntersection` added (minor)
- `react`: `useResize` added (minor)
- `react`: `useMatchMedia` now uses context instead global variable `matchMedia` (minor)
- `react`: `useBoundingClientRect` now uses context instead global variable `ResizeObserverContext` (minor)