### PR TITLE
React: useIntersection enhancement

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,7 @@ export default [
   ...tseslint.configs.recommended,
   {
     rules: {
+      'no-console': 'error',
       eqeqeq: 'error',
       '@typescript-eslint/no-explicit-any': 'off',
       'no-shadow': 'off',

--- a/scripts/sync-exports.ts
+++ b/scripts/sync-exports.ts
@@ -85,5 +85,6 @@ await glob('./src/**/mod.ts', { absolute: true })
     await new JsonFile('./jsr.json').set('exports', ctx.exportsJSR);
   })
   .then(() => {
+    // eslint-disable-next-line no-console
     console.log('Exports synced with "src" folder');
   });

--- a/src/math/clamp.ts
+++ b/src/math/clamp.ts
@@ -6,7 +6,7 @@
  * @returns Clamped value.
  */
 export function clamp(value: number, min: number, max: number): number {
-  // check that value is non NaN
+  // check that value is not a NaN
   if (value !== value) {
     return value;
   }

--- a/src/react/merge-refs.ts
+++ b/src/react/merge-refs.ts
@@ -1,4 +1,4 @@
-import type { MutableRefObject, Ref } from 'react';
+import type { Ref, RefObject, RefCallback, MutableRefObject } from 'react';
 
 /**
  * Create ref that updates all accepted refs from list.
@@ -6,13 +6,15 @@ import type { MutableRefObject, Ref } from 'react';
  * @param list Refs for merge.
  * @returns Merged ref.
  */
-export function mergeRefs<T>(list: Array<Ref<T> | null | undefined>): Ref<T> {
+export function mergeRefs<T>(
+  list: Array<Ref<T> | RefObject<T> | RefCallback<T> | MutableRefObject<T> | null | undefined>,
+): Ref<T> {
   return (value: T) => {
     for (const ref of list) {
       if (typeof ref === 'function') {
         ref(value);
       } else if (ref) {
-        (ref as MutableRefObject<T | null>).current = value;
+        ref.current = value;
       }
     }
   };

--- a/src/react/use-merge-refs.ts
+++ b/src/react/use-merge-refs.ts
@@ -1,4 +1,11 @@
-import { type Ref, useMemo, useRef } from 'react';
+import {
+  type Ref,
+  type RefCallback,
+  type RefObject,
+  type MutableRefObject,
+  useMemo,
+  useRef,
+} from 'react';
 import { mergeRefs } from './merge-refs.ts';
 
 /**
@@ -21,7 +28,9 @@ import { mergeRefs } from './merge-refs.ts';
  * @param refs Refs for merge.
  * @returns Merged ref.
  */
-export function useMergeRefs<T>(refs: Array<Ref<T> | null | undefined>): Ref<T> {
+export function useMergeRefs<T>(
+  refs: Array<Ref<T> | RefObject<T> | RefCallback<T> | MutableRefObject<T> | null | undefined>,
+): Ref<T> {
   const listRef = useRef(refs);
 
   // update listRef only when items is not same as in refs param

--- a/tests-e2e/stories/portal/primary.story.tsx
+++ b/tests-e2e/stories/portal/primary.story.tsx
@@ -15,7 +15,7 @@ export default function Example() {
 
       {open && (
         <Portal>
-          <h1>Hello, world!</h1>
+          <h1>Hello from Portal!</h1>
           <p>This content was rendered into new div at end of body.</p>
         </Portal>
       )}

--- a/tests-e2e/stories/portal/render-into-existing-element.story.tsx
+++ b/tests-e2e/stories/portal/render-into-existing-element.story.tsx
@@ -15,7 +15,7 @@ export default function Example() {
 
       {open && (
         <Portal container={() => document.querySelector('footer')!}>
-          <h1>Hello, world!</h1>
+          <h1>Hello from Portal!</h1>
           <p>This content was rendered to existing page footer.</p>
         </Portal>
       )}

--- a/tests-e2e/stories/use-intersection/primary.story.tsx
+++ b/tests-e2e/stories/use-intersection/primary.story.tsx
@@ -1,0 +1,53 @@
+import { type CSSProperties, useRef, useState } from 'react';
+import { useIntersection } from '@krutoo/utils/react';
+
+export const meta = {
+  category: 'React hooks/useIntersection',
+  title: 'Primary example',
+};
+
+const styles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+  } satisfies CSSProperties,
+
+  item: {
+    height: '100px',
+    borderRadius: '12px',
+    transition: 'background 500ms ease-in-out',
+  } satisfies CSSProperties,
+};
+
+function Item() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useIntersection(ref, entry => {
+    setVisible(entry.isIntersecting);
+  });
+
+  const style: CSSProperties = {
+    ...styles.item,
+    background: visible ? '#1abc9c' : '#2c3e50',
+  };
+
+  return <div ref={ref} style={style}></div>;
+}
+
+export default function Example() {
+  const items = [...Array(100).keys()];
+
+  return (
+    <>
+      <div style={styles.container}>
+        <h1>Blocks that are in viewport will be green</h1>
+        <p>Scroll the page for see effect</p>
+        {items.map(itemId => (
+          <Item key={itemId} />
+        ))}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
- react: useIntersection now handles known options changes (minor)
- react: mergeRefs now accepts MutableRef explicitly (for react <19 compat) (patch)
- react: useMergeRefs now accepts MutableRef explicitly (for react <19 compat) (patch)
- ESLint no-console rule
- some JSDoc fixes
- some e2e sandbox updates