### PR TITLE
React ref-hooks updates

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  test:
+  test-e2e:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  test:
+  test-unit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/react/mod.ts
+++ b/src/react/mod.ts
@@ -4,6 +4,7 @@ export * from './use-identity-ref.ts';
 export * from './use-isomorphic-layout-effect.ts';
 export * from './use-previous-state.ts';
 export * from './use-stable-callback.ts';
+export * from './use-dependent-ref.ts';
 
 // context
 export * from './context/intersection-observer-context.ts';

--- a/src/react/use-dependent-ref.ts
+++ b/src/react/use-dependent-ref.ts
@@ -1,0 +1,29 @@
+import { useMemo, useRef, type DependencyList, type RefObject } from 'react';
+
+const DEFAULT_DEPS: DependencyList = [];
+
+/**
+ * Returns ref that updates when some of dependency changes.
+ * @param initialValue Initial value in ref.
+ * @param deps Dependency list.
+ * @returns Ref.
+ */
+export function useDependentRef<T>(initialValue: T, deps?: DependencyList): RefObject<T> {
+  const ref = useRef<T>(initialValue);
+
+  return useMemo<RefObject<T>>(
+    () => {
+      return {
+        get current() {
+          return ref.current;
+        },
+        set current(value) {
+          ref.current = value;
+        },
+      };
+    },
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    deps ?? DEFAULT_DEPS,
+  );
+}

--- a/src/react/use-identity-ref.ts
+++ b/src/react/use-identity-ref.ts
@@ -1,4 +1,4 @@
-import { type DependencyList, type MutableRefObject, useMemo, useRef } from 'react';
+import { type MutableRefObject, useMemo, useRef } from 'react';
 
 /**
  * Returns ref that automatically actualizes current value.
@@ -20,18 +20,15 @@ import { type DependencyList, type MutableRefObject, useMemo, useRef } from 'rea
  * ```
  *
  * @param value Current value.
- * @param deps Deps. Works exactly like in useEffect.
  * @returns Ref object.
  */
-export function useIdentityRef<T>(value: T, deps: DependencyList = []): MutableRefObject<T> {
+export function useIdentityRef<T>(value: T): MutableRefObject<T> {
   const ref = useRef<T>(value);
 
   // useEffect is replaced by useMemo here because we need to set actual value during render, not after render
   useMemo<void>(() => {
     ref.current = value;
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value, ...deps]);
+  }, [value]);
 
   return ref;
 }


### PR DESCRIPTION
- react: useIdentityRef deps arg removed - there is no point (major)
- react: new hook useDependentRef added (minor)
- ci: test workflows names change (patch)