### PR TITLE
useDragAndDrop revision

### DIFF
--- a/docs/docs/react/use-drag-and-drop.mdx
+++ b/docs/docs/react/use-drag-and-drop.mdx
@@ -3,25 +3,39 @@
 export const meta = {
   category: 'React',
   title: 'useDragAndDrop',
+  menuPriority: -1,
 };
 
 Hook for adding ability to drag and drop some element.
 
-It returns object with:
+# Usage
 
-- `captured` - boolean that indicates that element is grabbed by mouse or touch
-- `offset` - object with `x` and `y` that means offset from element started position.
+Here is an example of simple draggable element
 
 ```tsx
 import { useDragAndDrop } from '@krutoo/utils/react';
-import { useRef, CSSProperties } from 'react';
+import { type CSSProperties, useRef, useState } from 'react';
 
 function App() {
   const ref = useRef<HTMLDivElement>(null);
 
-  const { captured, offset } = useDragAndDrop(ref);
+  const [grabbed, setGrabbed] = useState(false);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
 
-  const style: CSSProperties = captured
+  useDragAndDrop(ref, {
+    onGrab(event) {
+      setGrabbed(true);
+      setOffset(event.offset);
+    },
+    onMove(event) {
+      setOffset(event.offset);
+    },
+    onDrop() {
+      setGrabbed(false);
+    },
+  });
+
+  const style: CSSProperties = grabbed
     ? {
         position: 'absolute',
         top: `${offset.y}px`,
@@ -29,10 +43,6 @@ function App() {
       }
     : {};
 
-  return (
-    <div ref={ref} className='draggable'>
-      This block is draggable
-    </div>
-  );
+  return <div ref={ref}>This block is draggable</div>;
 }
 ```

--- a/src/react/constants.ts
+++ b/src/react/constants.ts
@@ -1,0 +1,7 @@
+import type { DependencyList } from 'react';
+
+/**
+ * Just an empty array.
+ * Need for micro-optimizations in cases when you don't want to create deps array on each render.
+ */
+export const zeroDeps: DependencyList = [];

--- a/src/react/mod.ts
+++ b/src/react/mod.ts
@@ -5,6 +5,7 @@ export * from './use-isomorphic-layout-effect.ts';
 export * from './use-previous-state.ts';
 export * from './use-stable-callback.ts';
 export * from './use-dependent-ref.ts';
+export * from './constants.ts';
 
 // context
 export * from './context/intersection-observer-context.ts';

--- a/src/react/use-dependent-ref.ts
+++ b/src/react/use-dependent-ref.ts
@@ -1,6 +1,5 @@
 import { useMemo, useRef, type DependencyList, type RefObject } from 'react';
-
-const zeroDeps: DependencyList = [];
+import { zeroDeps } from './constants.ts';
 
 /**
  * Returns ref that updates when some of dependency changes.

--- a/tests-e2e/stories/use-drag-and-drop/primary.story.tsx
+++ b/tests-e2e/stories/use-drag-and-drop/primary.story.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, useRef } from 'react';
+import { CSSProperties, useRef, useState } from 'react';
 import { useDragAndDrop } from '@krutoo/utils/react';
 import styles from './primary.m.css';
 
@@ -9,9 +9,23 @@ export const meta = {
 
 export default function Example() {
   const ref = useRef<HTMLDivElement>(null);
-  const { captured, offset } = useDragAndDrop(ref);
+  const [grabbed, setGrabbed] = useState(false);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
 
-  const style: CSSProperties = captured
+  useDragAndDrop(ref, {
+    onGrab(event) {
+      setGrabbed(true);
+      setOffset(event.offset);
+    },
+    onMove(event) {
+      setOffset(event.offset);
+    },
+    onDrop() {
+      setGrabbed(false);
+    },
+  });
+
+  const style: CSSProperties = grabbed
     ? {
         position: 'absolute',
         left: offset.x,

--- a/tsconfig.build-cjs.json
+++ b/tsconfig.build-cjs.json
@@ -9,7 +9,15 @@
     "verbatimModuleSyntax": false
   },
   "include": ["src"],
-  "exclude": ["node_modules", "./src/**/*.test.ts", "./src/**/*.test.tsx"],
+  "exclude": [
+    "node_modules",
+    "tests-pkg",
+    "tests-e2e",
+    "docs",
+    "dist",
+    "./src/**/*.test.ts",
+    "./src/**/*.test.tsx"
+  ],
   "tsc-alias": {
     "resolveFullPaths": true,
     "verbose": false

--- a/tsconfig.build-esm.json
+++ b/tsconfig.build-esm.json
@@ -7,7 +7,15 @@
     "outDir": "dist/esm"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "./src/**/*.test.ts", "./src/**/*.test.tsx"],
+  "exclude": [
+    "node_modules",
+    "tests-pkg",
+    "tests-e2e",
+    "docs",
+    "dist",
+    "./src/**/*.test.ts",
+    "./src/**/*.test.tsx"
+  ],
   "tsc-alias": {
     "resolveFullPaths": true,
     "verbose": false


### PR DESCRIPTION
- react: `useDragAndDrop` now returns `void`, you can define grabbed/offset state manually (major)
- react: `zeroDeps` added (minor)