### PR TITLE
React hooks improvements

### DIFF
--- a/docs/docs/react/use-bounding-client-rect.mdx
+++ b/docs/docs/react/use-bounding-client-rect.mdx
@@ -24,3 +24,17 @@ export function App() {
   return <div ref={ref}>Hello!</div>;
 }
 ```
+
+### Force update
+
+This hook uses next sources to update state:
+
+- it listens `scroll` event on document
+- it create `ResizeObserver` on target element
+
+However, tracking absolutely all actions that lead to a change in the size or position
+of an element is a difficult task.
+
+For example your element can have _css transition_ on hover.
+
+You can force hook to update state by calling `forceUpdate` method on returned object.

--- a/docs/docs/react/use-visual-viewport.mdx
+++ b/docs/docs/react/use-visual-viewport.mdx
@@ -22,3 +22,32 @@ This property contains boolean indicates hook is successfully started observing 
 It makes hook SSR ready.
 
 If `visualViewport` is not supported in browser, `ready` will be `false`.
+
+### Stateless mode
+
+If you want to observe `visualViewport` without re-render your component when it changes,
+you can provide `mode` option with `stateless` value.
+
+This will result in the return value not being up to date so you can ignore it.
+
+To listen changes you also can set callback to `onChange` option.
+
+```tsx
+import { useVisualViewport } from '@krutoo/utils/react';
+import { useRef } from 'react';
+
+function App() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useVisualViewport({
+    mode: 'stateless',
+    onChange(viewport) {
+      if (ref.current) {
+        ref.current.textContent = `Viewport width is ${viewport.width}`;
+      }
+    },
+  });
+
+  return <div ref={ref}></div>;
+}
+```

--- a/docs/docs/react/use-window-size.mdx
+++ b/docs/docs/react/use-window-size.mdx
@@ -24,3 +24,32 @@ export function App() {
   );
 }
 ```
+
+### Stateless mode
+
+If you want to observe window size without re-render your component when it changes,
+you can provide `mode` option with `stateless` value.
+
+This will result in the return value not being up to date so you can ignore it.
+
+To listen changes you also can set callback to `onChange` option.
+
+```tsx
+import { useWindowSize } from '@krutoo/utils/react';
+import { useRef } from 'react';
+
+function App() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useWindowSize({
+    mode: 'stateless',
+    onChange(windowSize) {
+      if (ref.current) {
+        ref.current.textContent = `Window width is ${windowSize.width}`;
+      }
+    },
+  });
+
+  return <div ref={ref}></div>;
+}
+```

--- a/src/misc/debounce.ts
+++ b/src/misc/debounce.ts
@@ -1,3 +1,10 @@
+export interface DebouncedFunction<T extends (this: any, ...args: any[]) => any> {
+  (this: ThisParameterType<T>, ...args: Parameters<T>): void;
+
+  /** Cancels registered future calls if exists. */
+  cancel: VoidFunction;
+}
+
 /**
  * Simplest implementation of "debounce" function.
  * Returns function wrapper that delays original function call
@@ -11,12 +18,18 @@
 export function debounce<T extends (...args: any) => any>(
   func: T,
   timeout: number,
-): (...args: Parameters<T>) => void {
+): DebouncedFunction<T> {
   let timerId: ReturnType<typeof setTimeout>;
 
-  return (...args) => {
+  const debounced: DebouncedFunction<T> = function (...args) {
     clearTimeout(timerId);
 
-    timerId = setTimeout(() => func(...args), timeout);
+    timerId = setTimeout(() => func.apply(this, args), timeout);
   };
+
+  debounced.cancel = () => {
+    clearTimeout(timerId);
+  };
+
+  return debounced;
 }

--- a/src/misc/mod.ts
+++ b/src/misc/mod.ts
@@ -7,3 +7,4 @@ export * from './pairs.ts';
 export * from './plural.ts';
 export * from './throttle.ts';
 export * from './wait.ts';
+export * from './noop.ts';

--- a/src/misc/noop.ts
+++ b/src/misc/noop.ts
@@ -1,0 +1,5 @@
+/**
+ * Function that does nothing.
+ * Useful as default value for callbacks.
+ */
+export function noop(): void {}

--- a/src/react/use-drag-and-drop.ts
+++ b/src/react/use-drag-and-drop.ts
@@ -88,7 +88,7 @@ export function useDragAndDrop<T extends HTMLElement>(
     onGrab,
     onMove,
     onDrop,
-    extraDeps = [],
+    extraDeps = zeroDeps,
     needPreventTouchEvent = canStartDrag,
   }: UseDragAndDropOptions = {},
 ): void {

--- a/src/react/use-window-size.ts
+++ b/src/react/use-window-size.ts
@@ -1,6 +1,45 @@
 import { useState } from 'react';
-import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect.ts';
 import type { RectSize } from '../math/mod.ts';
+import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect.ts';
+import { useIdentityRef } from './use-identity-ref.ts';
+import { useStableCallback } from './use-stable-callback.ts';
+import { noop } from '../misc/noop.ts';
+
+export interface RectSizeWithReady extends RectSize {
+  ready: boolean;
+}
+
+export interface UseWindowSizeOptions {
+  /**
+   * Mode of how hook will be work.
+   *
+   * Possible values:
+   * - `stateful` (default) - hook will update returned state and cause rerender.
+   * - `stateless` - hook will not update returned state.
+   *
+   * If you can observe window size without re-renders
+   * you can provide `mode: 'stateless'` and also `onChange` to listen changes.
+   */
+  mode?: 'stateful' | 'stateless';
+
+  /** Will be called each time window size changes. */
+  onChange?: (state: RectSize) => void;
+
+  /** Initial returned state. Used before subscription effect applied. */
+  defaultState?: RectSizeWithReady | (() => RectSizeWithReady);
+}
+
+/**
+ * Returns default state for `useWindowSize` hook.
+ * @returns Default state.
+ */
+function getInitialState(): RectSizeWithReady {
+  return {
+    ready: false,
+    width: 0,
+    height: 0,
+  };
+}
 
 /**
  * Hook of actual state of window width and height.
@@ -23,24 +62,31 @@ import type { RectSize } from '../math/mod.ts';
  * }
  * ```
  *
+ * @param options Options.
  * @returns Window size object with `width` and `height` properties.
  */
-export function useWindowSize(): RectSize & { ready: boolean } {
-  const [state, setState] = useState<RectSize & { ready: boolean }>(() => {
-    return {
-      width: 0,
-      height: 0,
-      ready: false,
-    };
-  });
+export function useWindowSize({
+  mode = 'stateful',
+  onChange = noop,
+  defaultState = getInitialState,
+}: UseWindowSizeOptions = {}): RectSizeWithReady {
+  const [state, setState] = useState<RectSizeWithReady>(defaultState);
+  const modeRef = useIdentityRef(mode);
+  const handleChange = useStableCallback(onChange);
 
   useIsomorphicLayoutEffect(() => {
     const syncState = () => {
-      setState({
+      const actualState = {
         ready: true,
         width: window.innerWidth,
         height: window.innerHeight,
-      });
+      };
+
+      if (modeRef.current === 'stateful') {
+        setState(actualState);
+      }
+
+      handleChange(actualState);
     };
 
     window.addEventListener('resize', syncState);
@@ -52,7 +98,7 @@ export function useWindowSize(): RectSize & { ready: boolean } {
       window.removeEventListener('resize', syncState);
       window.removeEventListener('orientationchange', syncState);
     };
-  }, []);
+  }, [modeRef, handleChange]);
 
   return state;
 }

--- a/tests-e2e/stories/use-visual-viewport/stateless.story.tsx
+++ b/tests-e2e/stories/use-visual-viewport/stateless.story.tsx
@@ -1,0 +1,38 @@
+import { CSSProperties, useRef } from 'react';
+import { useVisualViewport } from '@krutoo/utils/react';
+
+export const meta = {
+  category: 'React hooks/useVisualViewport',
+  title: 'Stateless mode',
+};
+
+export default function Example() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useVisualViewport({
+    mode: 'stateless',
+    onChange({ offsetTop, offsetLeft, width, height }) {
+      if (!ref.current) {
+        return;
+      }
+
+      ref.current.style.top = `${offsetTop}px`;
+      ref.current.style.left = `${offsetLeft}px`;
+      ref.current.style.width = `${width}px`;
+      ref.current.style.height = `${height}px`;
+      ref.current.innerHTML = `Viewport size:<br/>${width.toFixed()}px x ${height.toFixed()}px`;
+    },
+  });
+
+  const style: CSSProperties = {
+    position: 'fixed',
+    display: 'flex',
+    textAlign: 'center',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '12px',
+    boxShadow: 'inset 0 0 0 6px red',
+  };
+
+  return <div ref={ref} id='viewport' style={style}></div>;
+}


### PR DESCRIPTION
- `react`: `useBoundingClientRect` now return object with methods `forceUpdate` and `toJSON` (minor)
- `react`: `useVisualViewport` now provides new options mode and `onChange` (minor)
- `react`: `useWindowSize` now provides new options mode and `onChange` (minor)