### PR TITLE
React hook fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 Dmitriy Petrov
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/docs/react/use-dependent-ref.mdx
+++ b/docs/docs/react/use-dependent-ref.mdx
@@ -105,3 +105,12 @@ function MyComponent({ visible }: { visible: boolean }) {
 ```
 
 And it will work as expected.
+
+You may have noticed that in the last code example you could have simply added the `visible` prop
+to effect dependencies and then it would have worked the same way.
+
+But this approach would lead to the fact that you would have to add absolutely all variables
+that affect the display of your element to the effect dependencies.
+
+It is more convenient to make the ref dependent on these parameters
+and add ref itself to the dependencies.

--- a/docs/docs/react/use-visual-viewport.mdx
+++ b/docs/docs/react/use-visual-viewport.mdx
@@ -51,3 +51,5 @@ function App() {
   return <div ref={ref}></div>;
 }
 ```
+
+TODO describe how to use `VisualViewportContext`

--- a/src/dom/get-positioned-parent-offset.ts
+++ b/src/dom/get-positioned-parent-offset.ts
@@ -4,7 +4,7 @@ import { isScrollable } from './is-scrollable.ts';
 
 export interface PositioningOptions {
   /** How target (floating) element will be positioned. */
-  strategy?: 'fixed' | 'absolute';
+  strategy?: 'absolute' | 'fixed';
 }
 
 /**

--- a/src/react/__test__/portal.test.tsx
+++ b/src/react/__test__/portal.test.tsx
@@ -1,8 +1,8 @@
 import { describe, test } from 'node:test';
+import { expect } from '@std/expect';
 import { fireEvent, render } from '@testing-library/react';
 import { useState } from 'react';
 import { Portal } from '../portal.tsx';
-import { expect } from '@std/expect';
 
 function TestComponent() {
   const [open, setOpen] = useState(false);

--- a/src/react/__test__/use-resize.test.tsx
+++ b/src/react/__test__/use-resize.test.tsx
@@ -1,0 +1,55 @@
+import { describe, mock, test, type Mock } from 'node:test';
+import { expect } from '@std/expect';
+import { render } from '@testing-library/react';
+import { useRef } from 'react';
+import { useResize } from '../use-resize.ts';
+import { ResizeObserverContext, type ResizeObserverContextValue } from '../mod.ts';
+
+function TestComponent({ onResize }: { onResize?: VoidFunction }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useResize(ref, () => {
+    onResize?.();
+  });
+
+  return (
+    <div ref={ref} data-marker='greeting'>
+      Hello
+    </div>
+  );
+}
+
+describe('useResize', () => {
+  test('should use context to create observer', () => {
+    const fakeObserver: ResizeObserver = {
+      observe: mock.fn(),
+      unobserve: mock.fn(),
+      disconnect: mock.fn(),
+    };
+
+    const contextValue: ResizeObserverContextValue = {
+      getObserver() {
+        return fakeObserver;
+      },
+    };
+
+    expect((fakeObserver.observe as Mock<() => void>).mock.callCount()).toBe(0);
+    expect((fakeObserver.unobserve as Mock<() => void>).mock.callCount()).toBe(0);
+    expect((fakeObserver.disconnect as Mock<() => void>).mock.callCount()).toBe(0);
+
+    const { getByTestId, unmount } = render(
+      <ResizeObserverContext value={contextValue}>
+        <TestComponent />
+      </ResizeObserverContext>,
+    );
+    expect(getByTestId('greeting').textContent).toBe('Hello');
+    expect((fakeObserver.observe as Mock<() => void>).mock.callCount()).toBe(1);
+    expect((fakeObserver.unobserve as Mock<() => void>).mock.callCount()).toBe(0);
+    expect((fakeObserver.disconnect as Mock<() => void>).mock.callCount()).toBe(0);
+
+    unmount();
+    expect((fakeObserver.observe as Mock<() => void>).mock.callCount()).toBe(1);
+    expect((fakeObserver.unobserve as Mock<() => void>).mock.callCount()).toBe(1);
+    expect((fakeObserver.disconnect as Mock<() => void>).mock.callCount()).toBe(0);
+  });
+});

--- a/src/react/use-bounding-client-rect.ts
+++ b/src/react/use-bounding-client-rect.ts
@@ -114,9 +114,8 @@ export function useBoundingClientRect<T extends Element>(
     | MutableRefObject<T | undefined>,
   extraDeps: DependencyList = zeroDeps,
 ): UseBoundingClientRectReturn {
-  const [state, setState] = useState<DOMRectState>(DEFAULT_STATE);
-
   const { getObserver } = useContext(ResizeObserverContext);
+  const [state, setState] = useState<DOMRectState>(DEFAULT_STATE);
 
   const updateState = useCallback(() => {
     const element = ref.current;
@@ -143,7 +142,14 @@ export function useBoundingClientRect<T extends Element>(
       return;
     }
 
-    const observer = getObserver(updateState);
+    const observer = getObserver(entries => {
+      for (const entry of entries) {
+        if (entry.target === element) {
+          updateState();
+          return;
+        }
+      }
+    });
 
     observer.observe(element);
 

--- a/src/react/use-intersection.ts
+++ b/src/react/use-intersection.ts
@@ -107,6 +107,7 @@ export function useIntersection<T extends Element>(
       for (const entry of entries) {
         if (entry.target === element) {
           callbackRef.current(entry);
+          return;
         }
       }
     }, readyOptions);

--- a/src/react/use-resize.ts
+++ b/src/react/use-resize.ts
@@ -35,7 +35,6 @@ export function useResize<T extends Element>(
   callback: (entry: ResizeObserverEntry) => void,
 ): void {
   const { getObserver } = useContext(ResizeObserverContext);
-
   const callbackRef = useIdentityRef(callback);
 
   useIsomorphicLayoutEffect(() => {
@@ -45,10 +44,11 @@ export function useResize<T extends Element>(
       return;
     }
 
-    const observer = new ResizeObserver(entries => {
+    const observer = getObserver(entries => {
       for (const entry of entries) {
         if (entry.target === element) {
           callbackRef.current(entry);
+          return;
         }
       }
     });


### PR DESCRIPTION
- react: useResize now uses observer from context (patch)
- react: useResize finds only first entry in callback (patch)
- react: useIntersection finds only first entry in callback (patch)
- react: useBoundingClientRect finds only first entry in callback (patch)
- react: useResize tests added (patch)
- license fix (patch)
- some docs improvements (patch)
