### PR TITLE
feat(react): useBoundingClientRect is deprecated

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,5 +1,6 @@
 // IMPORTANT: "./react/mod.ts" is not added here because it requires "react" to be installed as a dependency
 // IMPORTANT: "./rspack/mod.ts" is not added here by the same reason
+// IMPORTANT: "./testing/mod.ts" is not added here because in practice it need only in test environment
 export * from './dom/mod.ts';
 export * from './math/mod.ts';
 export * from './types/mod.ts';

--- a/src/react/use-bounding-client-rect.ts
+++ b/src/react/use-bounding-client-rect.ts
@@ -103,6 +103,7 @@ function rectToState(rect: DOMRect | DOMRectReadOnly): DOMRectState {
  * @param ref Ref with element.
  * @param extraDeps Deps for force re init listeners.
  * @returns Rect state.
+ * @deprecated For detect element size use `useResize` instead.
  */
 export function useBoundingClientRect<T extends Element>(
   ref:


### PR DESCRIPTION
Need to use  instead for observe element' size

Also comment about missing testing module export from package root