### PR TITLE
feat(math): scaleRectToFit strategy option (contain/cover)

### DIFF
--- a/docs/docs/math/scale-rect-to-cover.mdx
+++ b/docs/docs/math/scale-rect-to-cover.mdx
@@ -1,9 +1,18 @@
+import { Callout } from '#components/callout/callout.tsx';
+
 # `scaleRectToCover`
 
 export const meta = {
   title: 'scaleRectToCover',
   category: 'Math',
 };
+
+<Callout level='danger'>
+  <Callout.Heading>Deprecated</Callout.Heading>
+  <Callout.Main>
+    Use <a href='./?path=/math/scale-rect-to-fit'>scaleRectToFit</a> instead
+  </Callout.Main>
+</Callout>
 
 Takes "target" rectangle and "area" rectangle and returns rectangle that has same ratio as "target" but covers "area" by size.
 

--- a/docs/docs/math/scale-rect-to-fit.mdx
+++ b/docs/docs/math/scale-rect-to-fit.mdx
@@ -7,7 +7,7 @@ export const meta = {
 
 Takes "target" rectangle and "area" rectangle and returns rectangle that has same ratio as "target" but fits to "area" size.
 
-Works like CSS rule `object-fit: contain`.
+Works like CSS rule `object-fit`, like `contain` by default.
 
 ```ts
 import { scaleRectToFit } from '@krutoo/utils';
@@ -16,6 +16,9 @@ const target = { width: 10, height: 10 };
 const area = { width: 100, height: 20 };
 
 scaleRectToFit(target, area); // { width: 20, height: 20 }
+
+// to make target rect cover area rect
+scaleRectToFit(target, area, 'cover'); // { width: 100, height: 100 }
 ```
 
 This function is useful for example when you need to scale some element on the page to fit other element with saving the original ratio.

--- a/src/math/__test__/scale-rect-to-fit.test.ts
+++ b/src/math/__test__/scale-rect-to-fit.test.ts
@@ -24,4 +24,16 @@ describe('scaleRectToFit', () => {
       height: 7.5,
     });
   });
+
+  test('should scale target rect to fit area rect', () => {
+    expect(scaleRectToFit({ width: 5, height: 5 }, { width: 10, height: 20 }, 'cover')).toEqual({
+      width: 20,
+      height: 20,
+    });
+
+    expect(scaleRectToFit({ width: 5, height: 5 }, { width: 30, height: 20 }, 'cover')).toEqual({
+      width: 30,
+      height: 30,
+    });
+  });
 });

--- a/src/math/scale-rect-to-cover.ts
+++ b/src/math/scale-rect-to-cover.ts
@@ -6,6 +6,7 @@ import type { RectSize } from './types.ts';
  * @param target Target box.
  * @param area Area box.
  * @returns New box that fits into area.
+ * @deprecated Use `scaleRectToFit(a, b, 'cover')` instead.
  */
 export function scaleRectToCover(target: RectSize, area: RectSize): RectSize {
   const scale = Math.max(area.width / target.width, area.height / target.height);

--- a/src/math/scale-rect-to-fit.ts
+++ b/src/math/scale-rect-to-fit.ts
@@ -2,13 +2,19 @@ import type { RectSize } from './types.ts';
 
 /**
  * Returns a rectangle that has same ratio as `target` but fits `area` by size.
- * Works like CSS-rule `object-fit: contain`.
+ * Works like CSS-rule `object-fit`, by default as `contain`.
  * @param target Target box.
  * @param area Area box.
+ * @param strategy Strategy, `contain` or `cover`.
  * @returns New box that fits into area.
  */
-export function scaleRectToFit(target: RectSize, area: RectSize): RectSize {
-  const scale = Math.min(area.width / target.width, area.height / target.height);
+export function scaleRectToFit(
+  target: RectSize,
+  area: RectSize,
+  strategy: 'contain' | 'cover' = 'contain',
+): RectSize {
+  const selector = strategy === 'cover' ? Math.max : Math.min;
+  const scale = selector(area.width / target.width, area.height / target.height);
 
   return {
     width: target.width * scale,

--- a/tests-e2e/.rspack/utils.ts
+++ b/tests-e2e/.rspack/utils.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import fs from 'node:fs/promises';
 import type { RspackPluginFunction } from '@rspack/core';
 import {
   type EmitStoriesEntrypointConfig,
@@ -39,15 +40,17 @@ export function pluginStoriesEntry(config: PluginStoriesEntryOptions): RspackPlu
   };
 }
 
-export async function aliasesToSource(fromPath: string) {
+export async function aliasesToSource(fromPath: string): Promise<Record<string, string>> {
+  const packageJson = JSON.parse(
+    await fs.readFile(path.resolve(import.meta.dirname, '../../package.json'), 'utf-8'),
+  );
+
   return {
-    '@krutoo/utils$': path.resolve(fromPath, '../src/mod.ts'),
-    '@krutoo/utils/dom$': path.resolve(fromPath, '../src/dom/mod.ts'),
-    '@krutoo/utils/math$': path.resolve(fromPath, '../src/math/mod.ts'),
-    '@krutoo/utils/misc$': path.resolve(fromPath, '../src/misc/mod.ts'),
-    '@krutoo/utils/react$': path.resolve(fromPath, '../src/react/mod.ts'),
-    '@krutoo/utils/rspack$': path.resolve(fromPath, '../src/rspack/mod.ts'),
-    '@krutoo/utils/types$': path.resolve(fromPath, '../src/types/mod.ts'),
+    ...Object.fromEntries(
+      Object.keys(packageJson.exports)
+        .filter(key => !key.startsWith('./typings'))
+        .map(key => [`${key}$`, path.resolve(fromPath, `${key}/mod.ts`)]),
+    ),
 
     // for avoiding errors about multiple react versions on the page
     react$: path.resolve(fromPath, 'node_modules/react'),


### PR DESCRIPTION
Also scaleRectToCover is deprecated